### PR TITLE
Use explicit `type` for column sort button

### DIFF
--- a/src/action-table.ts
+++ b/src/action-table.ts
@@ -457,6 +457,7 @@ export class ActionTable extends HTMLElement {
 						const button = document.createElement("button");
 						button.dataset.col = name;
 						button.innerHTML = th.innerHTML;
+						button.type = "button";
 						thClone.appendChild(button);
 						fragment.appendChild(thClone);
 					} else {


### PR DESCRIPTION
Hi @colinaut. Firstly, thanks for putting together this web component. I’ve been using it on a project in a variety of different ways, and it's proving really helpful and flexible enough for various situations.

I have however encountered one issue, when I have a table inside a `<form>`. As the column sorting buttons don’t include an explicit `type=button` attribute, sorting a column also submits the form.

On using the `button` value for the `type` attribute, [MDN says](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type):

> The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.

This describes the behaviour intended for the column sorting button, and testing this change on my project prevents the form from being submitted when pressed.